### PR TITLE
[DONT-MERGE] Setup locking wrapper in preSetup hook

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -1,3 +1,3 @@
 <?php
 
-OCP\Util::connectHook('OC_Filesystem', 'setup', '\OCA\Files_Locking\LockingWrapper', 'setupWrapper');
+OCP\Util::connectHook('OC_Filesystem', 'preSetup', '\OCA\Files_Locking\LockingWrapper', 'setupWrapper');


### PR DESCRIPTION
@icewind1991 in order to fix this for stable8 we would require the preSetup hook in core on stable8.

Kind of tricky ....

@karlitschek FYI
