### PR TITLE
Disable flock if transactional locking is enabled in core

### DIFF
--- a/lib/lockingwrapper.php
+++ b/lib/lockingwrapper.php
@@ -195,6 +195,12 @@ class LockingWrapper extends Wrapper {
 	 * Setup the storage wrapper callback
 	 */
 	public static function setupWrapper() {
+		$config = \OC::$server->getConfig();
+		if ($config->getSystemValue('filelocking.enabled', false)) {
+			// disable flock if transactional locking is enabled
+			return;
+		}
+
 		// Set up flock
 		\OC\Files\Filesystem::addStorageWrapper('oc_flock', function ($mountPoint, $storage) {
 			/**


### PR DESCRIPTION
@DeepDiver1975 @jnfrmarks @icewind1991 

It probably isn't useful to have both enabled at the same time.
