### PR TITLE
[stable8.2] Do set 8.2 as min and max version

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,9 @@
 	<name>File Locking</name>
 	<licence>AGPL</licence>
 	<author>Robin Appelman</author>
-	<require>6.0</require>
+	<dependencies>
+		<owncloud min-version="8.2" max-version="8.2" />
+	</dependencies>
 	<description>This application enables ownCloud to lock files while reading or writing to and from backend storage. The purpose of the app is to avoid file corruption during normal operation. Operating at a very low level in the ownCloud app, this application requests and respects file system locks. For example, when ownCloud is writing an uploaded file to the server, ownCloud requests a write lock. If the underlying storage supports locking, ownCloud will request and maintain an exclusive write lock for the duration of this write operation. When completed, ownCloud will then release the lock through the file system.
 If the file system does not support locking, there is no need to enable this application as any lock requested by ownCloud will not be honored in the underlying file system. More information is available in the File Locking documentation.
 	</description>


### PR DESCRIPTION
No need for this to be activated when people update to ownCloud 9.0. Especially as we don't test this at all.

@karlitschek @MTRichards Thoughts?
